### PR TITLE
Fix manifest icon paths for GitHub Pages

### DIFF
--- a/assets/manifest.webmanifest
+++ b/assets/manifest.webmanifest
@@ -10,13 +10,13 @@
   "theme_color": "#23b4ff",
   "icons": [
     {
-      "src": "assets/icons/icon-192.svg",
+      "src": "./icons/icon-192.svg",
       "sizes": "192x192",
       "type": "image/svg+xml",
       "purpose": "any maskable"
     },
     {
-      "src": "assets/icons/icon-512.svg",
+      "src": "./icons/icon-512.svg",
       "sizes": "512x512",
       "type": "image/svg+xml",
       "purpose": "any maskable"


### PR DESCRIPTION
## Summary
- update manifest icon URLs to be relative to the manifest file so they resolve on GitHub Pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d52d9b33448327b0a52e7b36107857