### PR TITLE
fix: bootstrap module version after DOM is ready

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -58,8 +58,7 @@ function fitLayout() {
   app.style.transform = prevTransform || '';
 }
 
-// Bootstrap the app (guard against double init)
-window.addEventListener('DOMContentLoaded', () => {
+function bootstrap() {
   if (window.__OTHELLO_BOOTSTRAPPED__) return;
   window.__OTHELLO_BOOTSTRAPPED__ = true;
   new OthelloApp();
@@ -86,7 +85,14 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     mo.observe(appEl, { childList: true, subtree: true, characterData: true });
   }
-});
+}
+
+// Bootstrap immediately if DOM 已经就绪，否则等待 DOMContentLoaded
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', bootstrap, { once: true });
+} else {
+  bootstrap();
+}
 
 // Also run after full load to account for fonts/layout shifts
 window.addEventListener('load', () => window.requestFit && window.requestFit());


### PR DESCRIPTION
## Summary
- ensure the module build bootstraps immediately if the DOM is already parsed
- keep the debounced layout fitting logic unchanged while reusing it in the new bootstrap helper

## Testing
- Manually served the site with `python3 -m http.server 4173` and verified the board renders correctly in Chromium

------
https://chatgpt.com/codex/tasks/task_e_68d5333699fc832781b3e74ee9a1f777