### PR TITLE
fix: align board fit logic and ai state

### DIFF
--- a/src/ai.bitboard.js
+++ b/src/ai.bitboard.js
@@ -643,8 +643,6 @@ export class AIEngine {
     const edgeDiff = myEdge - oppEdge;
 
     // longest horizontal/vertical runs (bias vs diagonal over-valuation)
-    const myBoard = player === BLACK ? black : white;
-    const oppBoard = player === BLACK ? white : black;
     const longestRun = (bb, isVertical) => {
       let best = 0;
       if (!isVertical) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,65 +1,84 @@
 import { OthelloApp } from './ui.js';
 
-// Fit engine: tune --cell-size to fit viewport; fall back to scaling
+function px(n) {
+  return Math.max(0, parseFloat(n) || 0);
+}
+
+function computeAvailable() {
+  const app = document.querySelector('.app');
+  const arena = document.querySelector('.arena');
+  const sidebar = document.querySelector('.sidebar');
+  const topBar = document.querySelector('.top-bar');
+  const footer = document.querySelector('.footer');
+  if (!app || !arena) return null;
+
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  const csApp = getComputedStyle(app);
+  const padY = px(csApp.paddingTop) + px(csApp.paddingBottom);
+  const rowGap = px(csApp.rowGap || csApp.gap);
+
+  const topH = topBar ? topBar.getBoundingClientRect().height : 0;
+  const footH = footer ? footer.getBoundingClientRect().height : 0;
+  const arenaMaxH = Math.max(0, vh - padY - topH - footH - rowGap * 2);
+
+  const arenaRect = arena.getBoundingClientRect();
+  let boardMaxW = arenaRect.width;
+  const csArena = getComputedStyle(arena);
+  const cols = (csArena.gridTemplateColumns || '').trim().split(/\s+/);
+  const twoCols = cols.length >= 2;
+  if (twoCols && sidebar) {
+    const sbr = sidebar.getBoundingClientRect();
+    const colGap = px(csArena.columnGap || csArena.gap);
+    boardMaxW = Math.max(0, arenaRect.width - sbr.width - colGap);
+  }
+
+  return { vw, vh, boardMaxW, boardMaxH: arenaMaxH };
+}
+
+// Fit engine: align with file:// fallback so both contexts share identical sizing
 function fitLayout() {
   const app = document.querySelector('.app');
   if (!app) return;
 
   const doc = document.documentElement;
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
+  const prevTransform = app.style.transform;
+  const prevScale = doc.style.getPropertyValue('--app-scale');
 
-  // Helper: measure natural size with current vars
-  const measure = () => {
-    const rect = app.getBoundingClientRect();
-    return { w: rect.width, h: rect.height };
-  };
-
-  // Disable scaling during search
+  app.style.transform = 'none';
   doc.style.setProperty('--app-scale', '1');
 
-  // Binary search the largest cell size that still keeps app within viewport
-  let lo = 26;  // px, minimum cell size
-  let hi = 160; // px, upper bound for large screens
-  let best = lo;
-
-  // Ensure app has no transform interfering with measurement
-  const prevTransform = app.style.transform;
-  app.style.transform = 'none';
-
-  for (let i = 0; i < 18; i++) {
-    const mid = Math.floor((lo + hi) / 2);
-    doc.style.setProperty('--cell-size', mid + 'px');
-    // Force reflow
-    void app.offsetWidth;
-    const { w, h } = measure();
-    if (w <= vw && h <= vh) {
-      best = mid;
-      lo = mid + 1;
+  const avail = computeAvailable();
+  if (!avail) {
+    app.style.transform = prevTransform || '';
+    if (prevScale) {
+      doc.style.setProperty('--app-scale', prevScale);
     } else {
-      hi = mid - 1;
+      doc.style.removeProperty('--app-scale');
     }
+    return;
   }
 
-  // Apply the best size
-  doc.style.setProperty('--cell-size', best + 'px');
-  void app.offsetWidth;
-  const { w: bw, h: bh } = measure();
+  const unit = 8 + 7 * 0.045 + 2 * 0.1;
+  const borderPx = 24;
+  const pxW = (avail.boardMaxW - borderPx) / unit;
+  const pxH = (avail.boardMaxH - borderPx) / unit;
+  const cell = Math.floor(Math.max(16, Math.min(pxW, pxH)));
 
-  // If still overflowing due to header/panels, scale uniformly as last resort
-  if (bw > vw || bh > vh) {
-    const scale = Math.min(1, vw / bw, vh / bh);
-    doc.style.setProperty('--app-scale', String(scale));
-  } else {
-    doc.style.setProperty('--app-scale', '1');
+  doc.style.setProperty('--cell-size', `${cell}px`);
+
+  const rect = app.getBoundingClientRect();
+  let scale = 1;
+  if (rect.width > avail.vw || rect.height > avail.vh) {
+    scale = Math.min(1, avail.vw / rect.width, avail.vh / rect.height);
   }
+  doc.style.setProperty('--app-scale', String(scale));
 
-  // Restore any inline transform (should be none after using CSS var)
   app.style.transform = prevTransform || '';
 }
 
-// Bootstrap the app (guard against double init)
-window.addEventListener('DOMContentLoaded', () => {
+function bootstrap() {
   if (window.__OTHELLO_BOOTSTRAPPED__) return;
   window.__OTHELLO_BOOTSTRAPPED__ = true;
   new OthelloApp();
@@ -86,7 +105,14 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     mo.observe(appEl, { childList: true, subtree: true, characterData: true });
   }
-});
+}
+
+// Bootstrap immediately if DOM 已经就绪，否则等待 DOMContentLoaded
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', bootstrap, { once: true });
+} else {
+  bootstrap();
+}
 
 // Also run after full load to account for fonts/layout shifts
 window.addEventListener('load', () => window.requestFit && window.requestFit());


### PR DESCRIPTION
## Summary
- align the module build's fit logic with the file:// fallback so the board sizing stays consistent
- restore requestFit to gracefully handle missing measurements before applying new styles
- fix the AI evaluation to reuse the existing board bitboards instead of redeclaring them twice

## Testing
- No automated tests were run (project does not include test scripts)


------
https://chatgpt.com/codex/tasks/task_e_68d5333699fc832781b3e74ee9a1f777